### PR TITLE
upcase module names

### DIFF
--- a/lib/nyudl/mdi/message.rb
+++ b/lib/nyudl/mdi/message.rb
@@ -1,7 +1,7 @@
 require "nyudl/mdi/message/version"
 
-module Nyudl
-  module Mdi
+module NYUDL
+  module MDI
     module Message
       # Your code goes here...
     end

--- a/lib/nyudl/mdi/message/version.rb
+++ b/lib/nyudl/mdi/message/version.rb
@@ -1,5 +1,5 @@
-module Nyudl
-  module Mdi
+module NYUDL
+  module MDI
     module Message
       VERSION = "0.0.1"
     end

--- a/nyudl-mdi-message.gemspec
+++ b/nyudl-mdi-message.gemspec
@@ -5,7 +5,7 @@ require 'nyudl/mdi/message/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "nyudl-mdi-message"
-  spec.version       = Nyudl::Mdi::Message::VERSION
+  spec.version       = NYUDL::MDI::Message::VERSION
   spec.authors       = ["jgpawletko"]
   spec.email         = ["jgpawletko@gmail.com"]
   spec.summary       = %q{Message classes for NYU DL Message Driven Infrastructure}


### PR DESCRIPTION
Change module names from 'Nyudl::Mdi' to 'NYUDL::MDI' thereby
following the Ruby Style Guide recommendation to [use uppercase
letters for acronyms](https://github.com/bbatsov/ruby-style-guide#camelcase-classes).
