### PR TITLE
Bug/preserve request

### DIFF
--- a/lib/nyudl/mdi/message/base.rb
+++ b/lib/nyudl/mdi/message/base.rb
@@ -11,7 +11,7 @@ module NYUDL
 
         def initialize(incoming = {})
           h[:version]    = MESSAGE_STRUCTURE_VERSION
-          h[:request_id] = SecureRandom.uuid
+          h[:request_id] = incoming[:request_id] || SecureRandom.uuid
           h[:params]     = incoming[:params]
         end
 

--- a/lib/nyudl/mdi/message/version.rb
+++ b/lib/nyudl/mdi/message/version.rb
@@ -2,7 +2,7 @@ module NYUDL
   module MDI
     # Module contains classes for messages that conform to a given format
     module Message
-      VERSION = '0.2.0'         # gem version
+      VERSION = '0.2.1'         # gem version
       MESSAGE_STRUCTURE_VERSION = '0.1.0'
     end
   end

--- a/spec/nyudl/mdi/message/base_spec.rb
+++ b/spec/nyudl/mdi/message/base_spec.rb
@@ -32,6 +32,16 @@ module NYUDL
             regexp  = /\A#{pattern}\z/
             expect(request_id).to match(regexp)
           end
+          context 'when instantiated without a request_id value' do
+            it 'returns a unique request_id' do
+              expect(Base.new.request_id).to_not be == request_id
+            end
+          end
+          context 'when instantiated with a request_id value' do
+            it 'returns the assigned value' do
+              expect(Base.new(request_id: request_id).request_id).to be == request_id
+            end
+          end
         end
         describe '#params' do
           context 'when no params hash provided to constructor' do

--- a/spec/nyudl/mdi/message/response_spec.rb
+++ b/spec/nyudl/mdi/message/response_spec.rb
@@ -7,6 +7,7 @@ module NYUDL
       describe Response do
         def valid_attributes
           {
+            request_id: 'f2bed5f1-a756-4da7-af00-0d479e0da099',
             outcome:    'success',
             start_time: Time.now.utc.iso8601,
             end_time:   Time.now.utc.iso8601,
@@ -196,6 +197,22 @@ module NYUDL
               data = 'this is some awesome data!'
               response.data = data
               expect(response.data).to be == data
+            end
+          end
+        end
+
+        describe '#request_id' do
+          context 'when instantiated without a request_id value' do
+            it 'returns a unique request_id' do
+              response = build(request_id: nil)
+              expect(response.request_id).to_not be == valid_attributes[:request_id]
+            end
+          end
+
+          context 'when instantiated without a request_id value' do
+            it 'returns the assigned value' do
+              response = build()
+              expect(response.request_id).to be == valid_attributes[:request_id]
             end
           end
         end


### PR DESCRIPTION
## Highlights
- fix `Base#request_id` behavior.  Old behavior minted a new `request_id` every time the constructor was called, however, this is incorrect behavior for the `Response` class, which should echo the incoming `request_id`.

Fixes #12 
